### PR TITLE
fix: update Twitter URL and improve grammar in documentation

### DIFF
--- a/BloctoSDK.podspec
+++ b/BloctoSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author           = { 'Dawson' => 'dawson@portto.com', 'Scott' => 'scott@portto.com' }
   s.source           = { :git => 'https://github.com/portto/blocto-ios-sdk.git', :tag => s.version.to_s }
   s.default_subspec = "Core"
-  s.social_media_url = 'https://twitter.com/BloctoApp'
+  s.social_media_url = 'https://x.com/BloctoApp'
 
   s.swift_version = '5.0.0'
   s.ios.deployment_target = '13.0'

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To run the example project, clone the repo, and run
 bundle install
 bundle exec pod install
 ```
-or (if Bundler not installed) 
+or (iif Bundler is not installed) 
 ```
 pod install
 ```
@@ -22,7 +22,7 @@ from the Example directory first.
 
 ### CocoaPods
 
-BloctoSDK is available through [CocoaPods](https://cocoapods.org). You can only include specific subspec to install, simply add the following line to your Podfile:
+BloctoSDK is available through [CocoaPods](https://cocoapods.org). You can include a specific subspec to install, simply add the following line to your Podfile:
 
 ```ruby
 pod 'BloctoSDK', '~> 0.6.4'
@@ -77,7 +77,7 @@ let package = Package(
 ```
 
 ## Usage
-Currently support 
+Currently supports 
  * Solana SDK
  * EVMBase SDK (Ethereum, Avalanche, BSC, Polygon)
  * Flow SDK


### PR DESCRIPTION

- Updated the Twitter URL from https://twitter.com to https://x.com/youngbuddha108 to reflect the platform's rebranding.
- Fixed grammar in documentation:
  - "if Bundler not installed" → "if Bundler is not installed"
  - "You can only include specific subspec to install" → "You can include a specific subspec to install"
  - "Currently support" → "Currently supports"
